### PR TITLE
Remove redundant ":action =>" from render.  

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
     if @user.update_attributes(params[:user])
 
     else
-      render :action => "edit"
+      render "edit"
     end
   end
 


### PR DESCRIPTION
Current Rais doesn't need ":action =>" when specifing a view because "action" word is very confusing whose meaning should be routing and controller method originally. 
