### PR TITLE
Stop warning when executing rake command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'rcov'
   gem 'ci_reporter'
-  gem 'cucumber-rails'
+  gem 'cucumber-rails', require: false
   gem 'database_cleaner'
 end
 


### PR DESCRIPTION
stop the following warning:

```
WARNING: Cucumber-rails required outside of env.rb.  The rest of loading is being defered until env.rb   is called.
To avoid this warning, move 'gem cucumber-rails' under only group :test in your Gemfile
```
